### PR TITLE
Add JPEG XL decoder

### DIFF
--- a/library/src/main/cpp/CMakeLists.txt
+++ b/library/src/main/cpp/CMakeLists.txt
@@ -9,6 +9,7 @@ option(WITH_PNG "Include PNG decoder" ON)
 option(WITH_WEBP "Include WebP decoder" ON)
 option(WITH_HEIF "Include HEIF decoder" ON)
 option(WITH_AVIF "Include AVIF decoder" ON)
+option(WITH_JXL "Include JXL decoder" ON)
 
 add_library(imagedecoder SHARED
   java_stream.cpp
@@ -42,5 +43,11 @@ if(WITH_HEIF OR WITH_AVIF)
   add_definitions(-DHAVE_LIBHEIF)
   target_sources(imagedecoder PRIVATE decoder_heif.cpp)
 endif()
+if(WITH_JXL)
+  add_subdirectory(libjxl)
+  add_definitions(-DHAVE_LIBJXL)
+  target_sources(imagedecoder PRIVATE decoder_jxl.cpp)
+endif()
+
 
 target_link_libraries(imagedecoder android jnigraphics log)

--- a/library/src/main/cpp/decoder_headers.h
+++ b/library/src/main/cpp/decoder_headers.h
@@ -50,4 +50,15 @@ ftyp_image_type get_ftyp_image_type(const uint8_t* data, uint32_t size) {
   return ftyp_image_type_no;
 }
 
+static uint8_t JXL_HEADER[] = "\0\0\0\x0cJXL \x0d\x0a......ftypjxl ";
+
+bool is_jxl(const uint8_t* data) {
+  for (uint32_t i = 0; i < 25; i++) {
+    if (data[i] != JXL_HEADER[i]) return false;
+    if (i == 9) i += 6;
+  }
+
+  return true;
+}
+
 #endif //IMAGEDECODER_DECODER_HEADERS_H

--- a/library/src/main/cpp/decoder_headers.h
+++ b/library/src/main/cpp/decoder_headers.h
@@ -50,15 +50,12 @@ ftyp_image_type get_ftyp_image_type(const uint8_t* data, uint32_t size) {
   return ftyp_image_type_no;
 }
 
-static uint8_t JXL_HEADER[] = "\0\0\0\x0cJXL \x0d\x0a......ftypjxl ";
-
 bool is_jxl(const uint8_t* data) {
-  for (uint32_t i = 0; i < 25; i++) {
-    if (data[i] != JXL_HEADER[i]) return false;
-    if (i == 9) i += 6;
-  }
-
-  return true;
+  return (data[0] == 0 && data[1] == 0 && data[2] == 0 && data[3] == 0xC &&
+          data[4] == 'J' && data[5] == 'X' && data[6] == 'L' &&
+          data[7] == ' ' && data[8] == 0xD && data[9] == 0xA &&
+          data[10] == 0x87 && data[11] == 0xA) || // container
+         (data[0] == 0xff && data[1] == 0x0a);    // codestream
 }
 
 #endif //IMAGEDECODER_DECODER_HEADERS_H

--- a/library/src/main/cpp/decoder_jxl.cpp
+++ b/library/src/main/cpp/decoder_jxl.cpp
@@ -1,0 +1,201 @@
+//
+// Created by w on 02/07/21.
+//
+
+#include "decoder_jxl.h"
+#include "row_convert.h"
+#include <vector>
+
+JpegxlDecoder::JpegxlDecoder(std::shared_ptr<Stream> &&stream, bool cropBorders)
+    : BaseDecoder(std::move(stream), cropBorders) {
+  this->info = parseInfo();
+}
+
+void decodeRGB(const uint8_t *data, size_t size, int channels,
+               std::vector<uint8_t> *pixels, JxlBasicInfo *jxl_info) {
+  auto runner = JxlThreadParallelRunnerMake(
+      nullptr, JxlThreadParallelRunnerDefaultNumWorkerThreads());
+
+  auto dec = JxlDecoderMake(nullptr);
+  if (JXL_DEC_SUCCESS !=
+      JxlDecoderSubscribeEvents(dec.get(),
+                                JXL_DEC_BASIC_INFO | JXL_DEC_FULL_IMAGE)) {
+    throw std::runtime_error("JxlDecoderSubscribeEvents failed");
+  }
+
+  if (JXL_DEC_SUCCESS != JxlDecoderSetParallelRunner(dec.get(),
+                                                     JxlThreadParallelRunner,
+                                                     runner.get())) {
+    throw std::runtime_error("JxlDecoderSetParallelRunner failed");
+  }
+
+  JxlDecoderSetInput(dec.get(), data, size);
+
+  for (;;) {
+    JxlDecoderStatus status = JxlDecoderProcessInput(dec.get());
+
+    if (status == JXL_DEC_ERROR) {
+      throw std::runtime_error("Decoder error");
+    } else if (status == JXL_DEC_NEED_MORE_INPUT) {
+      throw std::runtime_error("Error, already provided all input");
+    } else if (status == JXL_DEC_BASIC_INFO) {
+      if (JXL_DEC_SUCCESS != JxlDecoderGetBasicInfo(dec.get(), jxl_info)) {
+        throw std::runtime_error("JxlDecoderGetBasicInfo failed");
+      }
+    } else if (status == JXL_DEC_NEED_IMAGE_OUT_BUFFER) {
+      uint32_t num_channels;
+      if (channels == 0) {
+        num_channels =
+            (jxl_info->alpha_bits > 0 ? 1 : 0) + jxl_info->num_color_channels;
+      } else {
+        num_channels = channels;
+      }
+      JxlPixelFormat format = {num_channels, JXL_TYPE_UINT8, JXL_NATIVE_ENDIAN,
+                               0};
+
+      size_t buffer_size;
+      if (JXL_DEC_SUCCESS !=
+          JxlDecoderImageOutBufferSize(dec.get(), &format, &buffer_size)) {
+        throw std::runtime_error("JxlDecoderImageOutBufferSize failed");
+      }
+
+      pixels->resize(buffer_size);
+      void *pixels_buffer = (void *)pixels->data();
+      if (JXL_DEC_SUCCESS != JxlDecoderSetImageOutBuffer(dec.get(), &format,
+                                                         pixels_buffer,
+                                                         buffer_size)) {
+        throw std::runtime_error("JxlDecoderSetImageOutBuffer failed");
+      }
+    } else if (status == JXL_DEC_FULL_IMAGE) {
+    } else if (status == JXL_DEC_SUCCESS) {
+      break;
+    } else {
+      LOGW("Unexpected decoder status");
+      break;
+    }
+  }
+}
+
+ImageInfo JpegxlDecoder::parseInfo() {
+  Rect bounds;
+  JxlBasicInfo jxl_info;
+
+  if (cropBorders) {
+    std::vector<uint8_t> pixels;
+    decodeRGB(stream->bytes, stream->size, 0, &pixels, &jxl_info);
+
+    uint32_t num_pixels = jxl_info.xsize * jxl_info.ysize;
+    uint8_t *pixels_buffer = (uint8_t *)pixels.data();
+    uint32_t num_channels =
+        (jxl_info.alpha_bits > 0 ? 1 : 0) + jxl_info.num_color_channels;
+
+    if (num_channels == 2) {
+      for (int x = 0; x < num_pixels * num_channels; x += num_channels) {
+        pixels_buffer[x / num_channels] = pixels_buffer[x];
+      }
+    } else if (num_channels == 3 || num_channels == 4) {
+      for (int x = 0; x < num_pixels * num_channels; x += num_channels) {
+        uint8_t r = pixels_buffer[x + 0];
+        uint8_t g = pixels_buffer[x + 1];
+        uint8_t b = pixels_buffer[x + 2];
+        int gray = (r * 0.2126 + g * 0.7152 + b * 0.0722) + 0.5;
+        if (gray > 255) {
+          gray = 255;
+        }
+        pixels_buffer[x / num_channels] = (uint8_t)gray;
+      }
+    }
+
+    bounds = findBorders(pixels.data(), jxl_info.xsize, jxl_info.ysize);
+  } else {
+    auto dec = JxlDecoderMake(NULL);
+
+    if (JXL_DEC_SUCCESS !=
+        JxlDecoderSubscribeEvents(dec.get(), JXL_DEC_BASIC_INFO)) {
+      throw std::runtime_error("JxlDecoderSubscribeEvents failed");
+    }
+
+    JxlDecoderSetInput(dec.get(), stream->bytes, stream->size);
+
+    for (;;) {
+      JxlDecoderStatus status = JxlDecoderProcessInput(dec.get());
+
+      if (status == JXL_DEC_ERROR) {
+        throw std::runtime_error("Decoder error");
+      } else if (status == JXL_DEC_NEED_MORE_INPUT) {
+        throw std::runtime_error("Already provided all input");
+      } else if (status == JXL_DEC_BASIC_INFO) {
+        if (JXL_DEC_SUCCESS != JxlDecoderGetBasicInfo(dec.get(), &jxl_info)) {
+          throw std::runtime_error("JxlDecoderGetBasicInfo failed");
+        }
+        break;
+      } else if (status == JXL_DEC_SUCCESS) {
+        break;
+      } else {
+        LOGW("Unexpected decoder status");
+        break;
+      }
+    }
+
+    bounds = {
+        .x = 0, .y = 0, .width = jxl_info.xsize, .height = jxl_info.ysize};
+  }
+
+  return ImageInfo{.imageWidth = jxl_info.xsize,
+                   .imageHeight = jxl_info.ysize,
+                   .isAnimated = (bool)jxl_info.have_animation,
+                   .bounds = bounds};
+}
+
+void JpegxlDecoder::decode(uint8_t *outPixels, Rect outRect, Rect inRect,
+                           bool rgb565, uint32_t sampleSize) {
+
+  std::vector<uint8_t> pixels;
+  JxlBasicInfo jxl_info;
+  decodeRGB(stream->bytes, stream->size, 4, &pixels, &jxl_info);
+
+  // Copied from decoder_heif.cpp
+  int stride = 4 * info.imageWidth;
+  uint32_t inStride = stride;
+  uint32_t inStrideOffset = inRect.x * (stride / info.imageWidth);
+  auto inPixelsPos = (uint8_t *)pixels.data() + inStride * inRect.y;
+
+  // Calculate output stride
+  uint32_t outStride = outRect.width * (rgb565 ? 2 : 4);
+  uint8_t *outPixelsPos = outPixels;
+
+  // Set row conversion function
+  auto rowFn = rgb565 ? &RGBA8888_to_RGB565_row : &RGBA8888_to_RGBA8888_row;
+
+  if (sampleSize == 1) {
+    for (uint32_t i = 0; i < outRect.height; i++) {
+      // Apply row conversion function to the following row
+      rowFn(outPixelsPos, inPixelsPos + inStrideOffset, nullptr, outRect.width,
+            1);
+
+      // Shift row to read and write
+      inPixelsPos += inStride;
+      outPixelsPos += outStride;
+    }
+  } else {
+    // Calculate the number of rows to discard
+    uint32_t skipStart = (sampleSize - 2) / 2;
+    uint32_t skipEnd = sampleSize - 2 - skipStart;
+
+    for (uint32_t i = 0; i < outRect.height; ++i) {
+      // Skip starting rows
+      inPixelsPos += inStride * skipStart;
+
+      // Apply row conversion function to the following two rows
+      rowFn(outPixelsPos, inPixelsPos + inStrideOffset,
+            inPixelsPos + inStride + inStrideOffset, outRect.width, sampleSize);
+
+      // Shift row to read to the next 2 rows (the ones we've just read) + the
+      // skipped end rows
+      inPixelsPos += inStride * (2 + skipEnd);
+
+      // Shift row to write
+      outPixelsPos += outStride;
+    }
+  }
+}

--- a/library/src/main/cpp/decoder_jxl.cpp
+++ b/library/src/main/cpp/decoder_jxl.cpp
@@ -6,13 +6,13 @@
 #include "row_convert.h"
 #include <vector>
 
-JpegxlDecoder::JpegxlDecoder(std::shared_ptr<Stream> &&stream, bool cropBorders)
+JpegxlDecoder::JpegxlDecoder(std::shared_ptr<Stream>&& stream, bool cropBorders)
     : BaseDecoder(std::move(stream), cropBorders) {
   this->info = parseInfo();
 }
 
-void decodeRGB(const uint8_t *data, size_t size, int channels,
-               std::vector<uint8_t> *pixels, JxlBasicInfo *jxl_info) {
+void decodeRGB(const uint8_t* data, size_t size, int channels,
+               std::vector<uint8_t>* pixels, JxlBasicInfo* jxl_info) {
   auto runner = JxlThreadParallelRunnerMake(
       nullptr, JxlThreadParallelRunnerDefaultNumWorkerThreads());
 
@@ -60,7 +60,7 @@ void decodeRGB(const uint8_t *data, size_t size, int channels,
       }
 
       pixels->resize(buffer_size);
-      void *pixels_buffer = (void *)pixels->data();
+      void* pixels_buffer = (void*)pixels->data();
       if (JXL_DEC_SUCCESS != JxlDecoderSetImageOutBuffer(dec.get(), &format,
                                                          pixels_buffer,
                                                          buffer_size)) {
@@ -85,7 +85,7 @@ ImageInfo JpegxlDecoder::parseInfo() {
     decodeRGB(stream->bytes, stream->size, 0, &pixels, &jxl_info);
 
     uint32_t num_pixels = jxl_info.xsize * jxl_info.ysize;
-    uint8_t *pixels_buffer = (uint8_t *)pixels.data();
+    uint8_t* pixels_buffer = (uint8_t*)pixels.data();
     uint32_t num_channels =
         (jxl_info.alpha_bits > 0 ? 1 : 0) + jxl_info.num_color_channels;
 
@@ -143,11 +143,11 @@ ImageInfo JpegxlDecoder::parseInfo() {
 
   return ImageInfo{.imageWidth = jxl_info.xsize,
                    .imageHeight = jxl_info.ysize,
-                   .isAnimated = (bool)jxl_info.have_animation,
+                   .isAnimated = false, // (bool)jxl_info.have_animation,
                    .bounds = bounds};
 }
 
-void JpegxlDecoder::decode(uint8_t *outPixels, Rect outRect, Rect inRect,
+void JpegxlDecoder::decode(uint8_t* outPixels, Rect outRect, Rect inRect,
                            bool rgb565, uint32_t sampleSize) {
 
   std::vector<uint8_t> pixels;
@@ -158,11 +158,11 @@ void JpegxlDecoder::decode(uint8_t *outPixels, Rect outRect, Rect inRect,
   int stride = 4 * info.imageWidth;
   uint32_t inStride = stride;
   uint32_t inStrideOffset = inRect.x * (stride / info.imageWidth);
-  auto inPixelsPos = (uint8_t *)pixels.data() + inStride * inRect.y;
+  auto inPixelsPos = (uint8_t*)pixels.data() + inStride * inRect.y;
 
   // Calculate output stride
   uint32_t outStride = outRect.width * (rgb565 ? 2 : 4);
-  uint8_t *outPixelsPos = outPixels;
+  uint8_t* outPixelsPos = outPixels;
 
   // Set row conversion function
   auto rowFn = rgb565 ? &RGBA8888_to_RGB565_row : &RGBA8888_to_RGBA8888_row;

--- a/library/src/main/cpp/decoder_jxl.h
+++ b/library/src/main/cpp/decoder_jxl.h
@@ -1,0 +1,25 @@
+//
+// Created by w on 02/07/21.
+//
+
+#ifndef IMAGEDECODER_DECODER_JXL_H
+#define IMAGEDECODER_DECODER_JXL_H
+
+#include "decoder_base.h"
+#include <jxl/decode.h>
+#include <jxl/decode_cxx.h>
+#include <jxl/thread_parallel_runner.h>
+#include <jxl/thread_parallel_runner_cxx.h>
+
+class JpegxlDecoder : public BaseDecoder {
+public:
+  JpegxlDecoder(std::shared_ptr<Stream> &&stream, bool cropBorders);
+
+  void decode(uint8_t *outPixels, Rect outRect, Rect inRect, bool rgb565,
+              uint32_t sampleSize);
+
+private:
+  ImageInfo parseInfo();
+};
+
+#endif // IMAGEDECODER_DECODER_JXL_H

--- a/library/src/main/cpp/decoder_jxl.h
+++ b/library/src/main/cpp/decoder_jxl.h
@@ -8,8 +8,8 @@
 #include "decoder_base.h"
 #include <jxl/decode.h>
 #include <jxl/decode_cxx.h>
-#include <jxl/thread_parallel_runner.h>
-#include <jxl/thread_parallel_runner_cxx.h>
+#include <jxl/resizable_parallel_runner.h>
+#include <jxl/resizable_parallel_runner_cxx.h>
 
 class JpegxlDecoder : public BaseDecoder {
 public:

--- a/library/src/main/cpp/decoder_jxl.h
+++ b/library/src/main/cpp/decoder_jxl.h
@@ -13,9 +13,9 @@
 
 class JpegxlDecoder : public BaseDecoder {
 public:
-  JpegxlDecoder(std::shared_ptr<Stream> &&stream, bool cropBorders);
+  JpegxlDecoder(std::shared_ptr<Stream>&& stream, bool cropBorders);
 
-  void decode(uint8_t *outPixels, Rect outRect, Rect inRect, bool rgb565,
+  void decode(uint8_t* outPixels, Rect outRect, Rect inRect, bool rgb565,
               uint32_t sampleSize);
 
 private:

--- a/library/src/main/cpp/decoders.h
+++ b/library/src/main/cpp/decoders.h
@@ -18,5 +18,8 @@
 #ifdef HAVE_LIBHEIF
 #include "decoder_heif.h"
 #endif
+#ifdef HAVE_LIBJXL
+#include "decoder_jxl.h"
+#endif
 
 #endif //IMAGEDECODER_DECODERS_H

--- a/library/src/main/cpp/java_wrapper.cpp
+++ b/library/src/main/cpp/java_wrapper.cpp
@@ -54,6 +54,11 @@ Java_tachiyomi_decoder_ImageDecoder_nativeNewInstance(
       decoder = new HeifDecoder(std::move(stream), cropBorders);
     }
 #endif
+#ifdef HAVE_LIBJXL
+    else if (is_jxl(stream->bytes)) {
+      decoder = new JpegxlDecoder(std::move(stream), cropBorders);
+    }
+#endif
     else {
       LOGE("No decoder found to handle this stream");
       return nullptr;
@@ -161,6 +166,8 @@ Java_tachiyomi_decoder_ImageDecoder_nativeFindType(
     }
   } else if (is_gif(bytes)) {
     return create_image_type(env, 3, true);
+  } else if (is_jxl(bytes)) {
+    return create_image_type(env, 6, false);
   }
 
   switch (get_ftyp_image_type(bytes, toRead)) {

--- a/library/src/main/cpp/libjxl/CMakeLists.txt
+++ b/library/src/main/cpp/libjxl/CMakeLists.txt
@@ -1,0 +1,19 @@
+FetchContent_Declare(libjxl
+  GIT_REPOSITORY  https://github.com/libjxl/libjxl
+  GIT_TAG         c8b0bf3789351c9ccd8c48441354c522fd9ab188
+  BINARY_DIR      build
+  SUBBUILD_DIR    subbuild
+)
+
+set(JPEGXL_ENABLE_MANPAGES OFF CACHE INTERNAL "Build and install man pages for the command-line tools.")
+set(JPEGXL_ENABLE_BENCHMARK OFF CACHE INTERNAL "Build JPEGXL benchmark tools.")
+set(JPEGXL_ENABLE_EXAMPLES OFF CACHE INTERNAL "Build JPEGXL library usage examples.")
+set(JPEGXL_ENABLE_SJPEG OFF CACHE INTERNAL "Build JPEGXL with support for encoding with sjpeg.")
+set(JPEGXL_ENABLE_OPENEXR OFF CACHE INTERNAL "Build JPEGXL with support for OpenEXR if available.")
+
+option(BUILD_TESTING "" OFF)
+
+FetchContent_MakeAvailable(libjxl)
+
+target_include_directories(imagedecoder PRIVATE ${libjxl_BINARY_DIR} ${libjxl_SOURCE_DIR})
+target_link_libraries(imagedecoder jxl_dec-static jxl_threads-static)

--- a/library/src/main/java/tachiyomi/decoder/ImageType.kt
+++ b/library/src/main/java/tachiyomi/decoder/ImageType.kt
@@ -13,7 +13,7 @@ data class ImageType internal constructor(
 }
 
 enum class Format {
-  Jpeg, Png, Webp, Gif, Heif, Avif;
+  Jpeg, Png, Webp, Gif, Heif, Avif, Jxl;
 
   internal companion object {
     fun from(value: Int): Format {
@@ -25,6 +25,7 @@ enum class Format {
         3 -> Gif
         4 -> Heif
         5 -> Avif
+        6 -> Jxl
         else -> error("Invalid format code")
       }
     }


### PR DESCRIPTION
Add decoding of .jxl files using the [libjxl reference](https://github.com/libjxl/libjxl) implementation.
Does not do animated JXL or progressive decoding.