### PR TITLE
improve heif/heic detection

### DIFF
--- a/library/src/main/cpp/decoder_heif.cpp
+++ b/library/src/main/cpp/decoder_heif.cpp
@@ -6,7 +6,12 @@
 #include "row_convert.h"
 
 bool is_libheif_compatible(const uint8_t* bytes, uint32_t size) {
-  return heif_check_filetype(bytes, size) != heif_filetype_no;
+  if (size < 12) {
+    return false;
+  }
+
+  auto result = heif_check_filetype(bytes, size);
+  return (result != heif_filetype_no) && (result != heif_filetype_yes_unsupported);
 }
 
 auto init_heif_context(Stream* stream) {

--- a/library/src/main/cpp/decoder_heif.cpp
+++ b/library/src/main/cpp/decoder_heif.cpp
@@ -6,6 +6,7 @@
 #include "row_convert.h"
 
 bool is_libheif_compatible(const uint8_t* bytes, uint32_t size) {
+  //reject small invalid files that cause heif_check_filetype to return heif_filetype_maybe
   if (size < 12) {
     return false;
   }


### PR DESCRIPTION
closes #4 (i think)

this fixes the decoder detecting files below 8 bytes (and ftyp files <12 bytes) in size as HEIF files, and handles more of heif_check_filetype's return values.